### PR TITLE
Refactor/seperate manager from affinity matrix

### DIFF
--- a/src/corona_hakab_model/affinity_matrix.py
+++ b/src/corona_hakab_model/affinity_matrix.py
@@ -4,7 +4,8 @@ from random import sample, shuffle
 from typing import Iterable, List
 
 import numpy as np
-from agent import TrackingCircle
+from agent import TrackingCircle, Agent
+from consts import Consts
 
 use_parasymbolic_matrix = False
 if use_parasymbolic_matrix:
@@ -23,14 +24,11 @@ class AffinityMatrix:
     Naturally, W is symmetric.
     """
 
-    def __init__(self, manager, input_matrix_path: str = None, output_matrix_path: str = None):
-        self.consts = manager.consts
-        self.size = len(manager.agents)  # population size
+    def __init__(self, agents: Iterable[Agent], consts: Consts):
+        self.consts = consts
+        self.size = consts.populetion_size
+        assert len(agents) == consts.populetion_size, "Size of population doesn't match agent list size!"
         self.logger = logging.getLogger("simulation")
-
-        self.manager = manager
-        if input_matrix_path or output_matrix_path:
-            raise NotImplementedError
 
         self.logger.info("Building new AffinityMatrix")
         self.circular_matrix_types = {}
@@ -42,7 +40,7 @@ class AffinityMatrix:
         self.depth = j + 1
         self.inner = CoronaMatrix(self.size, self.depth)
 
-        self.agents = self.manager.agents
+        self.agents = agents
 
         self.logger.info("Building circular connections matrices")
 

--- a/src/corona_hakab_model/affinity_matrix.py
+++ b/src/corona_hakab_model/affinity_matrix.py
@@ -26,8 +26,8 @@ class AffinityMatrix:
 
     def __init__(self, agents: Iterable[Agent], consts: Consts):
         self.consts = consts
-        self.size = consts.populetion_size
-        assert len(agents) == consts.populetion_size, "Size of population doesn't match agent list size!"
+        self.size = consts.population_size
+        assert len(agents) == consts.population_size, "Size of population doesn't match agent list size!"
         self.logger = logging.getLogger("simulation")
 
         self.logger.info("Building new AffinityMatrix")

--- a/src/corona_hakab_model/affinity_matrix.py
+++ b/src/corona_hakab_model/affinity_matrix.py
@@ -4,7 +4,7 @@ from random import sample, shuffle
 from typing import Iterable, List
 
 import numpy as np
-from agent import TrackingCircle, Agent
+from agent import Agent, TrackingCircle
 from consts import Consts
 
 use_parasymbolic_matrix = False

--- a/src/corona_hakab_model/manager.py
+++ b/src/corona_hakab_model/manager.py
@@ -46,7 +46,7 @@ class SimulationManager:
 
         if input_matrix_path or output_matrix_path:
             raise NotImplementedError  # todo
-        self.matrix = AffinityMatrix(self)
+        self.matrix = AffinityMatrix(self.agents, self.consts)
 
         self.supervisor = Supervisor([Supervisable.coerce(a, self) for a in supervisable_makers], self)
         self.update_matrix_manager = update_matrix.UpdateMatrixManager(self.matrix)


### PR DESCRIPTION
AffinityMatrix (should be renamed to PopulationState or something similar, as it is about to contain much more than just one matrix. it already does...) should be oblivious to the manager holding it,  and only be used to hold the state of the population (agents and circles and such) and be only obidient to the parameters it was created with.
Changed the AffinityMatrix constructor to receive the agent list and  consts directly