### PR TITLE
Feature/policy affected circles to csv

### DIFF
--- a/src/corona_hakab_model/consts.py
+++ b/src/corona_hakab_model/consts.py
@@ -33,6 +33,9 @@ class Consts(NamedTuple):
     initial_infected_count: int = 20
     export_infected_agents_interval = 50
 
+    # Export statistics regarding the circles affected by activating a policy
+    export_activated_policies_stats = True
+
     # Size of population to estimate expected time for each state
     population_size_for_state_machine_analysis: int = 25_000
 

--- a/src/corona_hakab_model/consts.py
+++ b/src/corona_hakab_model/consts.py
@@ -34,6 +34,9 @@ class Consts(NamedTuple):
     total_steps: int = 350
     initial_infected_count: int = 20
     export_infected_agents_interval = 50
+
+    # Export statistics regarding the circles affected by activating a policy
+    export_activated_policies_stats = True
     
     # Size of population to estimate expected time for each state
     population_size_for_state_machine_analysis: int = 25_000

--- a/src/corona_hakab_model/manager.py
+++ b/src/corona_hakab_model/manager.py
@@ -217,5 +217,9 @@ class SimulationManager:
     def dump(self, **kwargs):
         return self.simulation_progression.dump(**kwargs)
 
+    # Queue trigger-based reports in the SimulationProgression object
+    def queue_report(self, report_type, df):
+        self.simulation_progression.queue_report(self.current_step, report_type, df)
+
     def __str__(self):
         return f"<SimulationManager: SIZE_OF_POPULATION={len(self.agents)}, " f"STEPS_TO_RUN={self.consts.total_steps}>"

--- a/src/corona_hakab_model/policies_manager.py
+++ b/src/corona_hakab_model/policies_manager.py
@@ -64,7 +64,7 @@ class PolicyManager:
         self.daily_affected_circles['policy_type'] += [conditioned_policy.message] * len(affected_circles)
         self.daily_affected_circles['circle_size'] += [c.agent_count for c in affected_circles]
         self.daily_affected_circles['circle_kind'] += [c.kind for c in affected_circles]
-        self.daily_affected_circles['circle_connection_type'] += [str(c.connection_type) for c in affected_circles]
+        self.daily_affected_circles['circle_connection_type'] += [c.connection_type.name for c in affected_circles]
 
     def add_message_to_manager(self, message: str):
         if message == "":


### PR DESCRIPTION
Added support for exporting trigger-based reports (i.e. reports that can't be generated periodically).
Added support to export policy activation statistics -- upon activating a policy, export the circles which were affected by it, their size and their type.