### PR TITLE
added automatic export to consts as a json file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+jsonpickle
 CppHeaderParser==2.7.4
 cycler==0.10.0
 joblib==0.14.1

--- a/src/corona_hakab_model/consts.py
+++ b/src/corona_hakab_model/consts.py
@@ -1,7 +1,8 @@
+import os
 from functools import lru_cache
 from itertools import count
 from typing import Dict, List, NamedTuple, Union
-
+import jsonpickle
 import numpy as np
 from numpy.random import random
 
@@ -44,7 +45,7 @@ class Consts(NamedTuple):
     LATENT_PRESYMP: str = "Latent-Presymp"
     # attributes and default values:
 
-    total_steps: int = 350
+    total_steps: int = 200
     initial_infected_count: int = 20
     export_infected_agents_interval: int = 50
 
@@ -294,6 +295,12 @@ class Consts(NamedTuple):
         parameters = eval(data, expressions)
 
         return cls(**parameters)
+
+    def export(self, export_path, file_name: str = "simulation_consts.json"):
+        if not file_name.endswith(".json"):
+            file_name += ".json"
+        with open(os.path.join(export_path, file_name), "w") as export_file:
+            export_file.write(jsonpickle.encode(self._asdict()))
 
     @lru_cache(None)
     def average_time_in_each_state(self) -> Dict[MedicalState, int]:

--- a/src/corona_hakab_model/generation/circles_consts.py
+++ b/src/corona_hakab_model/generation/circles_consts.py
@@ -1,10 +1,10 @@
+import os
 from typing import Dict, List, NamedTuple
-
+import jsonpickle
 from scipy.stats import rv_discrete
 
 from generation.connection_types import ConnectionTypes
 from util import randint
-import numpy as np
 
 """
 Overview:
@@ -114,8 +114,6 @@ class CirclesConsts(NamedTuple):
         {ConnectionTypes.Work: {"north": 0.2, "south": 0.8}},
     ]
 
-
-
     @classmethod
     def from_file(cls, param_path):
         """
@@ -135,6 +133,12 @@ class CirclesConsts(NamedTuple):
         parameters = eval(data, expressions)
 
         return cls(**parameters)
+
+    def export(self, export_path, file_name: str = "circles_consts.json"):
+        if not file_name.endswith(".json"):
+            file_name += ".json"
+        with open(os.path.join(export_path, file_name), "w") as export_file:
+            export_file.write(jsonpickle.encode(self._asdict()))
 
     def get_geographic_circles(self):
         assert self.geo_circles_amount == len(self.geo_circles)

--- a/src/corona_hakab_model/generation/generation_manager.py
+++ b/src/corona_hakab_model/generation/generation_manager.py
@@ -16,7 +16,7 @@ class GenerationManger:
     generation manager can export the entire generation information as a json.
     """
 
-    __slots__ = ("matrix_data", "population_data")
+    __slots__ = ("matrix_data", "population_data", "circles_consts", "matrix_consts")
 
     def __init__(self, circles_consts: CirclesConsts, matrix_consts: MatrixConsts):
         # setting logger
@@ -32,6 +32,12 @@ class GenerationManger:
         matrix_generation = MatrixGenerator(circles_generation.population_data, matrix_consts=matrix_consts)
         self.matrix_data = matrix_generation.matrix_data
 
+        # save consts to allow export
+        self.circles_consts = circles_consts
+        self.matrix_consts = matrix_consts
+
     def save_to_folder(self, folder):
         self.matrix_data.export(os.path.join(folder, 'matrix_data'))
         self.population_data.export(folder, 'population_data')
+        self.circles_consts.export(folder, 'circles_consts.json')
+        self.matrix_consts.export(folder, 'matrix_consts.json')

--- a/src/corona_hakab_model/generation/matrix_consts.py
+++ b/src/corona_hakab_model/generation/matrix_consts.py
@@ -1,4 +1,6 @@
+import os
 from typing import Dict, NamedTuple
+import jsonpickle
 import numpy as np
 from dataclasses import dataclass
 import math
@@ -85,6 +87,12 @@ class MatrixConsts(NamedTuple):
         parameters = eval(data, expressions)
 
         return cls(**parameters)
+
+    def export(self, export_path, file_name: str = "matrix_consts.json"):
+        if not file_name.endswith(".json"):
+            file_name += ".json"
+        with open(os.path.join(export_path, file_name), "w") as export_file:
+            export_file.write(jsonpickle.encode(self._asdict()))
 
     # overriding hash and eq to allow caching while using un-hashable attributes
     __hash__ = object.__hash__

--- a/src/corona_hakab_model/main.py
+++ b/src/corona_hakab_model/main.py
@@ -169,6 +169,8 @@ def run_simulation(args):
     print(sm)
     sm.run()
     df: pd.DataFrame = sm.dump(filename=args.output)
+    # using parent since args.output gives the sim_records folder
+    consts.export(export_path=Path(args.output).parent, file_name="simulation_consts.json")
     df.iloc[:, :-16].plot()
     if args.figure_path:
         if not os.path.splitext(args.figure_path)[1]:


### PR DESCRIPTION
we need a better export to the consts files than we currently have (hard-coping the parameters files).
this should do, however i am not sure that it is perfect either. the picklejson extracts a bit too much information. mainly rv_discretes are VARY annoying in this aspect.
i am not using regular json export since it can't handle complex objects.
the matrix_consts and circles_consts are great, but the simulation_consts comes out a bit too long.

note that this also adds a dependency to the project, i added it to the requirements.txt, let me know if it needs to be added elsewhere.

i think this is good enough, but i would like to hear your opinion. 

we also need to create a base class for all the consts, but that's for another conversation.