### PR TITLE
Fix connections bug

### DIFF
--- a/src/corona_hakab_model/generation/matrix_generator.py
+++ b/src/corona_hakab_model/generation/matrix_generator.py
@@ -25,9 +25,10 @@ from bsa.scipy_sparse import read_scipy_sparse
 from project_structure import OUTPUT_FOLDER
 
 
-class AgentConnections(NamedTuple):
-    daily_connections: Set[int] = set()
-    weekly_connections: Set[int] = set()
+class AgentConnections:
+    def __init__(self):
+        self.daily_connections: Set[int] = set()
+        self.weekly_connections: Set[int] = set()
 
 
 class ConnectionData:
@@ -36,8 +37,8 @@ class ConnectionData:
     )
 
     def __init__(self, agents):
-        self.connected_ids_by_strength = {agent: {connection_type: AgentConnections() for connection_type
-                                                                      in ConnectionTypes} for agent in agents}
+        self.connected_ids_by_strength = {agent.index: {connection_type: AgentConnections() for connection_type
+                                                        in ConnectionTypes} for agent in agents}
 
     def export(self, export_path, file_name="connection_data"):
         if not file_name.endswith(".pickle"):
@@ -191,10 +192,10 @@ class MatrixGenerator:
                     known_strengths[(agent.index, conn)] = strengthes[index]
 
                 if strengthes[index] == con_type_data.connection_strength:
-                    self.connection_data.connected_ids_by_strength[agent][
+                    self.connection_data.connected_ids_by_strength[agent.index][
                         con_type_data.connection_type].daily_connections.add(conn)
                 else:
-                    self.connection_data.connected_ids_by_strength[agent][
+                    self.connection_data.connected_ids_by_strength[agent.index][
                         con_type_data.connection_type].weekly_connections.add(conn)
 
 
@@ -216,7 +217,7 @@ class MatrixGenerator:
                 vals[i] = 0
                 self.matrix[depth, int(agent.index), ids] = vals
                 vals[i] = temp
-                self.connection_data.connected_ids_by_strength[agent][
+                self.connection_data.connected_ids_by_strength[agent.index][
                     con_type_data.connection_type].daily_connections.update(set(ids))
 
     def _create_scale_free_graph(self, con_type_data: ConnectionTypeData, circles: List[SocialCircle], depth):

--- a/src/corona_hakab_model/manager.py
+++ b/src/corona_hakab_model/manager.py
@@ -104,7 +104,7 @@ class SimulationManager:
         self.sick_agents = SickAgents()
 
         self.new_sick_counter = 0
-        self.new_sick_by_infection_method = {connection_type : 0 for connection_type in ConnectionTypes}
+        self.new_sick_by_infection_method = {connection_type: 0 for connection_type in ConnectionTypes}
         self.new_sick_by_infector_medical_state = {
                 "Latent": 0,
                 "Latent-Asymp": 0,


### PR DESCRIPTION
There was a bug were the connection for every agent were universally the same. More over, it actually created a fully connected graph FOR EVERY KIND OF CONNECTION.
The reason was that the NamedTuple was static, which made that add for certain agent's connection made all the other agents connection be affected too..
 